### PR TITLE
[24.01.22~24.01.26] 3주차 스터디 과제

### DIFF
--- a/week3/BOJ1003.java
+++ b/week3/BOJ1003.java
@@ -1,0 +1,28 @@
+import java.util.*;
+import java.io.*;
+
+public class BOJ1003{
+    static int[][] dp;
+    static int answer = 1;
+
+    public static void main(String args[]) throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int T = Integer.parseInt(br.readLine());
+
+        dp = new int[41][2];
+        dp[0][0] = 1;
+        dp[0][1] = 0;
+        dp[1][0] = 0;
+        dp[1][1] = 1;
+
+        for(int i = 2 ; i <=40; i++){
+            dp[i][0] += (dp[i-1][0] + dp[i-2][0]);
+            dp[i][1] += (dp[i-1][1] + dp[i-2][1]);
+        }
+
+        for(int i = 0 ; i < T ; i++){
+            int N = Integer.parseInt(br.readLine());
+            System.out.println(dp[N][0] + " " + dp[N][1]);
+        }
+    }
+}

--- a/week3/BOJ17182.java
+++ b/week3/BOJ17182.java
@@ -1,0 +1,57 @@
+import java.util.*;
+import java.io.*;
+
+public class BOJ17182{
+    
+    private static int N, K, ans = Integer.MAX_VALUE;
+    private static int[][] times;
+    private static boolean[] visited;
+    
+    public static void main(String args[]) throws IOException{
+
+        getInput();
+        
+        for(int h=0; h<N; h++) {
+            for(int i=0; i<N; i++) {
+                for(int j=0; j<N; j++) {
+                    if(i==j) continue;
+                    times[i][j] = Math.min(times[i][j], times[i][h]+times[h][j]);
+                }
+            }
+        }
+        visited[K] = true;
+        dfs(0,K,0);
+        System.out.println(ans);
+    }   
+    
+    public static void dfs(int level , int start, int sum) {
+        if(level == N-1) {
+            ans = Math.min(ans, sum);
+            return ;
+        }
+        
+        for(int i=0; i<N; i++) {
+            if(!visited[i]) {
+                visited[i] = true;
+                dfs(level+1,i,sum+ times[start][i]);
+                visited[i] = false;
+            }
+        }
+    }
+    
+    private static void getInput() throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+        times = new int[N][N];
+        visited = new boolean[N];
+        
+        for(int i = 0 ; i < N ; i++){
+            st = new StringTokenizer(br.readLine());
+            for(int j = 0 ; j < N ; j++){
+                times[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+    }
+}

--- a/week3/BOJ18428.java
+++ b/week3/BOJ18428.java
@@ -1,0 +1,92 @@
+import java.util.*;
+import java.io.*;
+
+public class BOJ18428 {
+	static int N, answer, count;
+	static char[][] board;
+	static boolean[][] visit;
+	static boolean flag = false;
+    static int[][] unit = {{-1,0},{0,1},{1,0},{0,-1}};
+	static List<Node> teachers = new ArrayList<>();
+			
+	public static void main(String[] args) throws IOException{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+		
+		board = new char[N][N];
+		for (int i = 0; i < N; i++) {
+    		st = new StringTokenizer(br.readLine());
+    		for(int j = 0 ; j < N ; j++){
+    			board[i][j] = st.nextToken().charAt(0);
+    			if(board[i][j] == 'T') {
+    			    teachers.add(new Node(i, j));
+    			}
+		    }
+		}
+            
+		combination(0);
+		
+		if(flag) 
+		    System.out.println("YES");
+		else System.out.println("NO"); 
+		
+	}
+	
+	static void combination(int cnt) {
+	    if(flag) return;
+        if (cnt == 3) {
+            check();
+            return;
+        }
+
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < N; j++) {
+                if (board[i][j] == 'X') {
+                    board[i][j] = 'O';
+                    combination(cnt+1);
+                    board[i][j] = 'X';
+                }
+            }
+        }
+    }
+	
+	public static void check() {
+		Queue<Node> q = new LinkedList<>();
+		for(Node teacher : teachers){
+		    q.offer(teacher);
+		}
+		
+		while(!q.isEmpty()){
+		    Node node = q.poll();
+            int x = node.x;
+            int y = node.y;
+            
+		    for(int i = 0 ; i < 4 ; i++){
+		        int nx = x + unit[i][0];
+		        int ny = y + unit[i][1];
+		      
+		        while(nx >= 0 && nx < N && ny >= 0 && ny < N){
+		            if(board[nx][ny] == 'S') return;
+		            if(board[nx][ny] != 'X') break;
+		            nx +=unit[i][0];
+		            ny +=unit[i][1];
+		        }
+		      
+		    }
+		}
+		
+		flag = true;
+		return;
+	}
+	
+	static class Node{
+        int x;
+        int y;
+
+        public Node(int x, int y) {
+            this.x = x;
+            this.y = y;
+        }
+    }
+}

--- a/week3/BOJ2302.java
+++ b/week3/BOJ2302.java
@@ -1,0 +1,32 @@
+import java.util.*;
+import java.io.*;
+
+public class BOJ2302 {
+    static int[] dp;
+    static int answer = 1;
+    
+    public static void main(String args[]) throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int seats = Integer.parseInt(br.readLine());
+        int vipNum = Integer.parseInt(br.readLine());
+        
+        dp = new int[seats+2] ;
+        dp[0] = 1;
+        dp[1] = 1;
+        dp[2] = 2;
+            
+        for(int i = 3 ; i <= seats; i++){
+            dp[i] = dp[i-1] + dp[i-2];
+        }
+        
+        int bf = 0;
+        for(int i = 0 ; i< vipNum ; i++){
+            int vip = Integer.parseInt(br.readLine());
+            answer *= dp[vip-bf-1];
+            bf = vip;
+        }
+        answer *= dp[seats-bf];
+        
+        System.out.println(answer);
+    }
+}

--- a/week3/BOJ3109.java
+++ b/week3/BOJ3109.java
@@ -1,0 +1,48 @@
+import java.util.*;
+import java.io.*;
+
+public class BOJ3109 {
+	static int R,C,answer;
+	static char[][] board;
+    static int[][] unit = {{-1,1},{0,1},{1,1}};
+	static boolean finished;
+			
+	public static void main(String[] args) throws IOException{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        R = Integer.parseInt(st.nextToken());
+		C = Integer.parseInt(st.nextToken());
+		
+		board = new char[R][C];
+		for (int i = 0; i < R; i++) {
+		    st = new StringTokenizer(br.readLine());
+			board[i] = st.nextToken().toCharArray();
+		}
+		
+		for (int i = 0; i < R; i++) {
+			finished = false;
+			board[i][0] = '@';
+			dfs(i,0);
+		}
+		System.out.println(answer);
+	}
+	
+	public static void dfs(int x, int y) {
+		
+		if(y == C-1) {
+			finished = true;          
+			answer++;
+			return;
+		}
+		
+		for (int i = 0; i < 3; i++) {
+			int nx = x + unit[i][0];
+			int ny = y + unit[i][1];
+			if(nx<0 || nx>=R || ny>=C || board[nx][ny] == 'x' || board[nx][ny] == '@') continue;
+			if(finished) continue;
+			board[nx][ny] = '@';
+			dfs(nx,ny);
+		}
+		
+	}
+}


### PR DESCRIPTION
## 💡 [24.01.22~24.01.26] 3주차 스터디 과제 

**문제 리스트**
|문제명|링크|
|:---:|:---|
|우주 탐사선|[Link🔗](https://www.acmicpc.net/problem/17182)|
|빵집|[Link🔗](https://www.acmicpc.net/problem/3109)|
|감시 피하기|[Link🔗](https://www.acmicpc.net/problem/18428)|
|극장 좌석|[Link🔗](https://www.acmicpc.net/problem/2302)|
|피보나치 함수|[Link🔗](https://www.acmicpc.net/problem/1003)|

### 문제 세부

<details>
<summary><h4>우주 탐사선(BOJ17182.java)</h4></summary>
<h4>풀이</h4>

[참고](https://suhyeokeee.tistory.com/231)
times[i][j] -> i에서 j까지 가는 데 걸리는 시간
i -> j 시간과 i -> h -> j 시간을 비교하여 최솟값을 times[i][j]에 저장
+) 내가 헷갈렸던 부분
times[i][j]에 이미  i -> h1 -> j에 걸리는 시간이 저장되어있으면
i -> h1 -> h2 -> j가 더 빠르다면, h2를 추가한 시간을 저장할 수 있음

그 다음 dfs로 최단 거리 계산

</details>

<details>
<summary><h4>빵집(BOJ3109.java)</h4></summary>
<h4>풀이</h4>

[참고](https://velog.io/@qwerty1434/%EB%B0%B1%EC%A4%80-3109%EB%B2%88-%EB%B9%B5%EC%A7%91)

매 행 board[i][0]에서 시작, ➡️ ↗️ ↘️ 으로 탐색
최대한 위를 향하는 경로일수록 많은 경로를 가질 수 있다 - Greedy

visit표시 '@'로 대체

dfs로 탐색하며 가능한 경우 계산
마지막 행에 도달했다면, 해당 시작점에서 찾을 수 있는 모든 경로를 찾은 것임

</details>
<details>
<summary><h4>감시 피하기 (BOJ18428.java)</h4></summary>
<h4>풀이</h4>

실수리스트
- x1 y1, x1 y1보다 큰 값을 가진 x2 y2, x2 y2보다 큰 값을 가진 x3 y3으로 계산하려함. x1 < x2인데, y1 > y2인 경우는 계산 못함 어이없음
- 직진밖에 못하는데 그냥 dfs로 전 방향 다 돌림

조합을 이용하여 장애물이 있을 수 있는 모든 경우의 수를 구하고,
선생님들의 위치를 순회하며 직진시켜서 학생하고 부딪히는 선생님이 있는지 확인
없으면 YES 출력

</details>

<details>
<summary><h4>극장 좌석(BOJ2302.java)</h4></summary>
<h4>풀이</h4>

vip의 좌석을 기준으로 나누어 생각.
d[i] -> i명을 섞는 경우의 수
ex) ooovooovoo 일 경우, d[3]*d[2]*d[2]

처음에 1~N명 섞는 경우의 수 계산
vip 관객을 만날 때마다 그 전까지의 수 k명의 d[k]를 answer에 곱합

</details>

<details>
<summary><h4>피보나치 함수(BOJ1003.java)</h4></summary>
<h4>풀이</h4>

d[i][j] (j = 0,1)는 i를 피보나치 함수로 계산했을 때, j가 출력되는 횟수
40까지의 수를 모두 계산해 놓음
f(0) = 0
f(1) = 1
f(2) = 10
f(3) = 101
f(4) = 10110
이 출력되므로
dp[i][j] += (dp[i-1][j] + dp[i-2][j])

그다음 주어진 테스트케이스에 맞춰 출력

</details>

### Issue
- #8 
- Close #8 
